### PR TITLE
Fix error when we are deleting the accordion block in edit mode.

### DIFF
--- a/packages/volto-accordion-block/src/components/AccordionEdit.jsx
+++ b/packages/volto-accordion-block/src/components/AccordionEdit.jsx
@@ -43,7 +43,9 @@ const AccordionEdit = (props) => {
   };
 
   React.useEffect(() => {
-    return data.collapsed && setActiveIndex([]);
+    if (data.collapsed) {
+      setActiveIndex([]);
+    }
   }, [data.collapsed]);
 
   return (


### PR DESCRIPTION
In useeffect we can only return the function. Not a javascript code.